### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project has adopted the [Contributor Covenant Code of Conduct](https://docs.rapids.ai/resources/conduct/).


### PR DESCRIPTION
This PR creates an organization-wide `CODE_OF_CONDUCT.md`. Currently we have some discrepancy across repos:
- rmm, cusignal, clx maintain [their own files with full text](https://github.com/rapidsai/rmm/blob/4da70d53986a66fa11588cab7ab20fe26d172abe/CODE_OF_CONDUCT.md)
- cuDF, kvikio maintain [their own short file](https://github.com/rapidsai/cudf/blob/a8c0f4be674bb782ccd8739481479fcfa2982502/CODE_OF_CONDUCT.md) with a link to https://docs.rapids.ai/resources/conduct/
- cuML, cuGraph, cuSpatial, and all others have no `CODE_OF_CONDUCT.md` file

If this PR is merged, the Code of Conduct will appear in the sidebar like this for all `rapidsai` repos:
![image](https://user-images.githubusercontent.com/3943761/202204990-0a7ad91d-afad-46e5-8689-a9a2f01cd9bc.png)

I will file follow-up PRs to remove the explicit files from rmm, cudf, cusignal, kvikio, clx.